### PR TITLE
basic-auth-improvement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
 
   private
 
+  def production?
+    Rails.env.production?
+  end
+
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == 'admin' && password == '2222'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -60,3 +60,6 @@
 #     # password: "please use keys"
 #   }
 server '18.176.175.55', user: 'ec2-user', roles: %w{app db web}
+
+set :rails_env, "production"
+set :unicorn_rack_env, "production"


### PR DESCRIPTION
# What
- Basic認証のusernameとpasswordを環境変数化した。
- 本番環境でのみBasic認証を要求するよう変更した。

# Why
- ソースコード内にusernameとpasswordが記述されており、セキュアではなかったから。
- 開発環境で毎回Basic認証を求められるのは煩わしかった為